### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 
 2.部分分离模式，以点击位置为分界点，部分item分离
 
-##用法
+## 用法
 在代码中
 
 	PullSeparateListView lv = (PullSeparateListView) findViewById(R.id.pullExpandListView);


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
